### PR TITLE
fix: initial stab at resolving the null document bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.figs.contentful.java</groupId>
   <artifactId>java-sdk</artifactId>
-  <version>10.5.22</version>
+  <version>10.5.23</version>
   <packaging>jar</packaging>
 
   <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/com/contentful/java/cda/rich/RichTextFactory.java
+++ b/src/main/java/com/contentful/java/cda/rich/RichTextFactory.java
@@ -168,8 +168,10 @@ public class RichTextFactory {
 
         for (final String locale : rawValue.keySet()) {
             final CDARichDocument document = entry.getField(locale, field.id());
-            for (final CDARichNode node : document.getContent()) {
-                resolveOneLink(array, field, locale, node);
+            if (document != null) {
+                for (final CDARichNode node : document.getContent()) {
+                    resolveOneLink(array, field, locale, node);
+                }
             }
         }
     }


### PR DESCRIPTION
Error in existing code:
Caused by: java.lang.NullPointerException: Cannot invoke "com.contentful.java.cda.rich.CDARichDocument.getContent()" because "document" is null
	at com.contentful.java.cda.rich.RichTextFactory.resolveRichLink(RichTextFactory.java:171)
	at com.contentful.java.cda.rich.RichTextFactory.resolveRichTextField(RichTextFactory.java:80)
	at com.contentful.java.cda.ResourceFactory.array(ResourceFactory.java:33)
	
	
This adds a null check to prevent this exception.